### PR TITLE
Fix missing return type for generated Swift actions

### DIFF
--- a/lib/fastlane/plugin/bitrise_automation/actions/bitrise_build_status_action.rb
+++ b/lib/fastlane/plugin/bitrise_automation/actions/bitrise_build_status_action.rb
@@ -40,6 +40,10 @@ module Fastlane
         "Returns the information of the Bitrise build"
       end
 
+      def self.return_type
+        :hash
+      end
+
       def self.available_options
         [
           FastlaneCore::ConfigItem.new(key: :app_slug,

--- a/lib/fastlane/plugin/bitrise_automation/actions/trigger_bitrise_workflow_action.rb
+++ b/lib/fastlane/plugin/bitrise_automation/actions/trigger_bitrise_workflow_action.rb
@@ -89,6 +89,10 @@ module Fastlane
         "Returns the information of the Bitrise build"
       end
 
+      def self.return_type
+        :hash
+      end
+
       def self.available_options
         [
           FastlaneCore::ConfigItem.new(key: :app_slug,

--- a/spec/bitrise_build_status_action_spec.rb
+++ b/spec/bitrise_build_status_action_spec.rb
@@ -35,4 +35,10 @@ describe Fastlane::Actions::BitriseBuildStatusAction do
       end.to raise_error(FastlaneCore::Interface::FastlaneCrash)
     end
   end
+
+  describe 'return type' do
+    it 'is :hash' do
+      expect(Fastlane::Actions::BitriseBuildStatusAction.return_type).to eq(:hash)
+    end
+  end
 end

--- a/spec/trigger_bitrise_workflow_action_spec.rb
+++ b/spec/trigger_bitrise_workflow_action_spec.rb
@@ -399,4 +399,10 @@ describe Fastlane::Actions::TriggerBitriseWorkflowAction do
       end.to raise_error(FastlaneCore::Interface::FastlaneBuildFailure)
     end
   end
+
+  describe 'return type' do
+    it 'is :hash' do
+      expect(Fastlane::Actions::TriggerBitriseWorkflowAction.return_type).to eq(:hash)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

### Proposed changes

This PR brings the following changes:

- Fix missing return type for generated Swift actions

### Related issue

https://github.com/natura-cosmeticos/fastlane-plugin-bitrise-automation/issues/3

### Dependencies added/removed (if applicable)

---

### Testing

- [x] I have added or updated tests that prove my fix is effective or that my feature works (if applicable)
  - [x] Unit test
  - [ ] Snapshot test
  - [ ] Manual test
  - [ ] Another test...

#### How to test

Describe the tests that you ran to verify your changes:

1. Run `bundle install && bundle exec fastlane generate_swift`
2. Open `fastlane/swift/Plugins.swift`
3. Check if the generated Swift actions have return type

#### Test configuration

$ ruby -v
ruby 2.6.3p62 (2019-04-16 revision 67580) [universal.x86_64-darwin20]
$ bundle -v
Bundler version 2.2.22
$ fastlane -v
fastlane 2.191.0

---

## Checklist

- [ ] I have added corresponding labels to this PR (like bug, enhancement...);
- [ ] My commits follow the [Conventional Commits 1.0 Guidelines](https://www.conventionalcommits.org/en/v1.0.0/);
- [x] My code follows the style guidelines of this project;
- [x] I have performed a self-review of my own code;
- [ ] I have mapped technical debts found on my changes;
- [ ] I have made corresponding changes to the documentation (if applicable);
- [x] My changes generate no new warnings or errors;
